### PR TITLE
Minimize database size

### DIFF
--- a/novelsave/database/tables/keyvalue.py
+++ b/novelsave/database/tables/keyvalue.py
@@ -7,7 +7,7 @@ class KeyValueTable(Table):
 
     def put(self, key, value):
         self.data[key] = value
-        self.save()
+        self.flush()
 
     def get(self, key, default=None):
         return self.data.get(key, default)

--- a/novelsave/database/tables/keyvalue.py
+++ b/novelsave/database/tables/keyvalue.py
@@ -13,7 +13,10 @@ class KeyValueTable(Table):
         return self.data.get(key, default)
 
     def remove(self, key):
-        del self.data[key]
+        try:
+            del self.data[key]
+        except KeyError:
+            pass
 
     def all(self):
         return dict(self.data)

--- a/novelsave/database/tables/multi.py
+++ b/novelsave/database/tables/multi.py
@@ -1,4 +1,4 @@
-from typing import List, Iterable, Dict
+from typing import List, Iterable, Dict, Union
 
 from .template import ProcessedTable
 from ...models import Chapter
@@ -62,13 +62,11 @@ class MultiClassTable(ProcessedTable):
         del self.data[id]
         self.flush()
 
-    def pre_process(self, data: List[Dict]) -> Dict:
-        processed = {}
-
-        for item in data:
-            processed[item[self.identifier]] = item
-
-        return processed
+    def pre_process(self, data: Union[List[Dict], Dict]) -> Dict:
+        if type(data) == list:
+            return {item[self.identifier]: item for item in data}
+        else:
+            return data
 
     def post_process(self, data: Dict) -> List[Dict]:
         return list(data.values())

--- a/novelsave/database/tables/multi.py
+++ b/novelsave/database/tables/multi.py
@@ -1,4 +1,4 @@
-from typing import List, Iterable, Dict, Union
+from typing import List, Iterable, Dict, Union, Optional
 
 from .template import ProcessedTable
 from ...models import Chapter
@@ -44,13 +44,17 @@ class MultiClassTable(ProcessedTable):
         """
         return [self._from_dict(o) for o in self.data.values()]
 
-    def get(self, id) -> Chapter:
+    def get(self, id, default=None) -> Optional[Chapter]:
         """
         :param id: unique identifier
+        :param default: return this value when key doesnt exist
         :return: chapter with corresponding id
         :raises ValueError: if more than one value corresponds to key
         """
-        return self._from_dict(self.data[id])
+        try:
+            return self._from_dict(self.data[id])
+        except KeyError:
+            return default
 
     def remove(self, id):
         """
@@ -59,8 +63,11 @@ class MultiClassTable(ProcessedTable):
         :param id: id of obj to remove
         :return: None
         """
-        del self.data[id]
-        self.flush()
+        try:
+            del self.data[id]
+            self.flush()
+        except KeyError:
+            pass
 
     def pre_process(self, data: Union[List[Dict], Dict]) -> Dict:
         if type(data) == list:

--- a/novelsave/database/tables/multi.py
+++ b/novelsave/database/tables/multi.py
@@ -32,7 +32,7 @@ class MultiClassTable(Table):
         except KeyError:
             self.data[id] = self._to_dict(obj)
 
-        self.save()
+        self.flush()
 
     def put(self, obj):
         """
@@ -42,7 +42,7 @@ class MultiClassTable(Table):
         :return: None
         """
         self.data[getattr(obj, self.identifier)] = self._to_dict(obj)
-        self.save()
+        self.flush()
 
     def put_all(self, objs: Iterable):
         """
@@ -52,7 +52,7 @@ class MultiClassTable(Table):
         :return: None
         """
         self.data.update({getattr(obj, self.identifier): self._to_dict(obj) for obj in objs})
-        self.save()
+        self.flush()
 
     def all(self) -> List:
         """
@@ -76,7 +76,7 @@ class MultiClassTable(Table):
         :return: None
         """
         del self.data[id]
-        self.save()
+        self.flush()
 
     def _to_dict(self, obj) -> dict:
         return {field: getattr(obj, field) for field in self.fields}

--- a/novelsave/database/tables/set_sequence.py
+++ b/novelsave/database/tables/set_sequence.py
@@ -19,6 +19,7 @@ class SetTable(Table):
         for i, item in enumerate(data):
             if all([obj[field] == item[field] for field in self.fields]):
                 del data[i]
+                break
 
         data.append(obj)
         self.flush()

--- a/novelsave/database/tables/set_sequence.py
+++ b/novelsave/database/tables/set_sequence.py
@@ -21,7 +21,7 @@ class SetTable(Table):
                 del data[i]
 
         data.append(obj)
-        self.save()
+        self.flush()
 
     def all(self) -> List[dict]:
         return self.data
@@ -33,7 +33,7 @@ class SetTable(Table):
             if all([obj[field] == item[field] for field in self.fields]):
                 del data[i]
 
-        self.save()
+        self.flush()
 
     def search_where(self, key, value):
         docs = []
@@ -62,4 +62,4 @@ class SetTable(Table):
             except KeyError:
                 pass
 
-        self.save()
+        self.flush()

--- a/novelsave/database/tables/single.py
+++ b/novelsave/database/tables/single.py
@@ -12,7 +12,7 @@ class SingleClassTable(KeyValueTable):
 
     def set(self, values):
         self.data.update({field: getattr(values, field) for field in self.fields})
-        self.save()
+        self.flush()
 
     def parse(self):
         return self.cls(**{key: value for key, value in self.data.items() if key in self.fields})

--- a/novelsave/database/tables/template.py
+++ b/novelsave/database/tables/template.py
@@ -6,6 +6,12 @@ Serializable = Union[Dict, List]
 
 
 class Table:
+    """
+    TODO
+    - should hold the changes until saved: flush()
+    - apply post processing before applying to main dict
+    """
+
     def __init__(self, db: DatabaseTemplate, table: str, default_factory: Callable[[], Serializable] = lambda: {}):
         self.db = db
         self.table = table
@@ -16,16 +22,50 @@ class Table:
         try:
             return self.db.get_table(self.table)
         except KeyError:
-            self.db.set_table(self.table, self.default_factory())
-            return self.db.get_table(self.table)
+            return self.db.set_table(self.table, self.default_factory())
 
     @data.setter
     def data(self, data: Serializable):
         self.db.set_table(self.table, data)
         self.db.save()
 
-    def save(self):
+    def flush(self):
         self.db.save()
 
     def truncate(self):
         self.data = self.default_factory()
+
+
+class ProcessedTable(Table):
+    def __init__(self, db: DatabaseTemplate, table: str, default_factory: Callable[[], Serializable] = lambda: {}):
+        super(ProcessedTable, self).__init__(db, table, default_factory)
+        self._buffer = None
+
+    @property
+    def data(self) -> Serializable:
+        if self._buffer is None:
+            try:
+                data = self.db.get_table(self.table)
+            except KeyError:
+                data = self.db.set_table(self.table, self.default_factory())
+
+            self._buffer = self.pre_process(data)
+
+        return self._buffer
+
+    @data.setter
+    def data(self, data: Serializable):
+        self._buffer = data
+
+    def flush(self):
+        self.db.set_table(self.table, self.post_process(self._buffer))
+        self.db.save()
+
+    def truncate(self):
+        self.data = self.default_factory()
+
+    def pre_process(self, data):
+        return data
+
+    def post_process(self, data):
+        return data

--- a/novelsave/database/template.py
+++ b/novelsave/database/template.py
@@ -15,6 +15,7 @@ class DatabaseTemplate:
 
     def set_table(self, key: str, data: Dict):
         self._data[key] = data
+        return data
 
     def save(self):
         raise NotImplementedError

--- a/test/database/tables/keyvalue_test.py
+++ b/test/database/tables/keyvalue_test.py
@@ -29,6 +29,7 @@ class TestKeyValueTable(unittest.TestCase):
         self.assertEqual('value', self.table.get('key'))
 
     def test_get_default(self):
+        self.assertIsNone(self.table.get('key'))
         self.assertEqual('default', self.table.get('key', 'default'))
 
     def test_remove(self):
@@ -40,8 +41,7 @@ class TestKeyValueTable(unittest.TestCase):
         self.assertEqual(0, len(self.db._data[self.table_name]))
 
     def test_remove_nonexistent(self):
-        with self.assertRaises(KeyError):
-            self.table.remove('key')
+        self.table.remove('key')
 
     def test_all(self):
         d = {'key': 'value', 'key1': 'value1', 'key2': 'value2'}

--- a/test/database/tables/multi_test.py
+++ b/test/database/tables/multi_test.py
@@ -49,28 +49,52 @@ class TestMultiClassTable(unittest.TestCase):
         self.db = Database(':memory:')
         self.table = MultiClassTable(self.db, self.table_name, TestClass, self.fields, 'id')
 
-    def test_insert(self):
-        self.table.insert(self.tc1)
+    def test_pre_process(self):
+        test_data = [
+            vars(self.tc1),
+            vars(self.tc2),
+        ]
 
-        data = self.db._data[self.table_name]
+        processed_data = self.table.pre_process(test_data)
 
-        self.assertIsInstance(data, dict)
-        self.assertEqual(1, len(data))
-        self.assertEqual(self.tc1, TestClass(**data[1]))
+        self.assertIsInstance(processed_data, dict)
+        self.assertEqual(2, len(processed_data))
+        self.assertDictEqual(vars(self.tc1), processed_data[self.tc1.id])
+        self.assertDictEqual(vars(self.tc2), processed_data[self.tc2.id])
 
-    def test_insert_conflict(self):
-        self.table.insert(self.tc1)
-        with self.assertRaises(ValueError):
-            self.table.insert(self.tc1c)
+    def test_post_process(self):
+        test_data = {
+            self.tc1.id: vars(self.tc1),
+            self.tc2.id: vars(self.tc2),
+        }
+
+        processed_data = self.table.post_process(test_data)
+
+        self.assertIsInstance(processed_data, list)
+        self.assertEqual(2, len(processed_data))
+        self.assertDictEqual(vars(self.tc1), processed_data[0])
+        self.assertDictEqual(vars(self.tc2), processed_data[1])
+
+    def test_process_cycle(self):
+        test_data = [
+            vars(self.tc1),
+            vars(self.tc2),
+        ]
+
+        pre_processed = self.table.pre_process(test_data)
+        post_processed = self.table.post_process(pre_processed)
+
+        for i in range(len(test_data)):
+            self.assertDictEqual(test_data[i], post_processed[i])
 
     def test_put(self):
         self.table.put(self.tc1)
 
         data = self.db._data[self.table_name]
 
-        self.assertIsInstance(data, dict)
+        self.assertIsInstance(data, list)
         self.assertEqual(1, len(data))
-        self.assertEqual(self.tc1, TestClass(**data[self.tc1.id]))
+        self.assertEqual(self.tc1, TestClass(**data[0]))
 
     def test_put_conflict(self):
         self.table.put(self.tc1)
@@ -78,16 +102,16 @@ class TestMultiClassTable(unittest.TestCase):
 
         data = self.db._data[self.table_name]
 
-        self.assertIsInstance(data, dict)
+        self.assertIsInstance(data, list)
         self.assertEqual(1, len(data))
-        self.assertEqual(self.tc1c, TestClass(**data[self.tc1.id]))
+        self.assertEqual(self.tc1c, TestClass(**data[0]))
 
     def test_put_all(self):
         self.table.put_all([self.tc1, self.tc2])
 
         data = self.db._data[self.table_name]
 
-        self.assertIsInstance(data, dict)
+        self.assertIsInstance(data, list)
         self.assertEqual(2, len(data))
 
     def test_put_all_duplicate(self):
@@ -95,7 +119,7 @@ class TestMultiClassTable(unittest.TestCase):
 
         data = self.db._data[self.table_name]
 
-        self.assertIsInstance(data, dict)
+        self.assertIsInstance(data, list)
         self.assertEqual(1, len(data))
 
     def test_put_all_conflict(self):
@@ -104,29 +128,29 @@ class TestMultiClassTable(unittest.TestCase):
 
         data = self.db._data[self.table_name]
 
-        self.assertIsInstance(data, dict)
+        self.assertIsInstance(data, list)
         self.assertEqual(2, len(data))
 
     def test_get(self):
-        self.table.insert(self.tc1)
+        self.table.put(self.tc1)
 
         data = self.db._data[self.table_name]
-        self.assertIsInstance(data, dict)
+        self.assertIsInstance(data, list)
         self.assertEqual(1, len(data))
         self.assertEqual(self.tc1, self.table.get(1))
 
     def test_remove(self):
-        self.table.insert(self.tc1)
+        self.table.put(self.tc1)
         self.table.remove(self.tc1.id)
 
         data = self.db._data[self.table_name]
 
-        self.assertIsInstance(data, dict)
+        self.assertIsInstance(data, list)
         self.assertEqual(0, len(data))
 
     def test_all(self):
-        self.table.insert(self.tc1)
-        self.table.insert(self.tc2)
+        self.table.put(self.tc1)
+        self.table.put(self.tc2)
 
         data = self.table.all()
 

--- a/test/database/tables/multi_test.py
+++ b/test/database/tables/multi_test.py
@@ -151,6 +151,10 @@ class TestMultiClassTable(unittest.TestCase):
         self.assertEqual(1, len(data))
         self.assertEqual(self.tc1, self.table.get(1))
 
+    def test_get_default(self):
+        self.assertIsNone(self.table.get('missing'))
+        self.assertEqual('default', self.table.get('missing', 'default'))
+
     def test_remove(self):
         self.table.put(self.tc1)
         self.table.remove(self.tc1.id)
@@ -159,6 +163,9 @@ class TestMultiClassTable(unittest.TestCase):
 
         self.assertIsInstance(data, list)
         self.assertEqual(0, len(data))
+
+    def test_remove_nonexistent(self):
+        self.table.remove('something')
 
     def test_all(self):
         self.table.put(self.tc1)

--- a/test/database/tables/multi_test.py
+++ b/test/database/tables/multi_test.py
@@ -62,6 +62,18 @@ class TestMultiClassTable(unittest.TestCase):
         self.assertDictEqual(vars(self.tc1), processed_data[self.tc1.id])
         self.assertDictEqual(vars(self.tc2), processed_data[self.tc2.id])
 
+    def test_pre_process_dict_format(self):
+        test_data = {
+            self.tc1.id: vars(self.tc1),
+            self.tc2.id: vars(self.tc2),
+        }
+
+        processed_data = self.table.pre_process(test_data)
+
+        self.assertIsInstance(processed_data, dict)
+        self.assertEqual(2, len(processed_data))
+        self.assertDictEqual(test_data, processed_data)
+
     def test_post_process(self):
         test_data = {
             self.tc1.id: vars(self.tc1),


### PR DESCRIPTION
# Minimize database size

One of the side effects of transitioning to built-in database (#32) from was increased size for _pending.db_.

Size of _pending.db_ was increased by approximately 1.5 times.

This is a major increase in size and the size of _pending.db_ with 3000 chapters in it can increase to 750kb as opposed to the same amount in tinydb which was 500kb.

750kb in itself is not much, but when considering how the db is rewritten every time a chapter is downloaded it can bottleneck the download speed.

This pull request solves the issue of size. The size of pending is reduced to on par with tinydb (or a tiny bit better).

## Processed Table

The processed table inherits from Table.

However it uses a buffer that is post-processed before being written to the main data.

The data in memory is post-processed to a more minimal form before being saved.

When the data is being read from the disk it is pre-processed to a more suitable form.

### Pending.db

In pending.db this processing removes the duplication of id. This admittedly small thing adds up quickly.

#### Memory

```json
{
    "id-value": {
        "id": "id-value",
        "field": "value"
    }
}
```

#### Disk

```json
[
    {
        "id": "id-value",
        "field": "value"
    }
]
```